### PR TITLE
Convert xsd:complexType with mixed content and no element children to text

### DIFF
--- a/xsdtorngconverter/XSDtoRNG.xsl
+++ b/xsdtorngconverter/XSDtoRNG.xsl
@@ -324,6 +324,12 @@ explicit removal of enumeration as not all the XSLT processor respect templates 
 					<rng:empty/>
 					<xsl:apply-templates/>
 				</xsl:when>
+                                <!-- An empty xsd:complexType with @mixed='true' is equivalent to text -->
+                                <xsl:when test="not(@type) and *[local-name() = 'complexType' and @mixed = 'true' and not(*)]">
+                                  <xsl:apply-templates/>
+                                  <!-- Allow text but no elements -->
+                                  <rng:text/>
+                                </xsl:when>
 				<xsl:otherwise>
 					<xsl:apply-templates/>
 				</xsl:otherwise>


### PR DESCRIPTION
I've made a change to the xs:element template because it was failing on the Jasper Reports schema.  

A complexType with @mixed='true' allows text interspersed with the elements
that are legal for it, but if there are no elements, that leaves us with
just text; thus it is equivalent to plain text.

I hope this will be useful.

Thanks.

Ed
